### PR TITLE
Update player spawn location

### DIFF
--- a/objects/obj_player/Step_0.gml
+++ b/objects/obj_player/Step_0.gml
@@ -99,6 +99,10 @@ if (place_meeting(x, y + player_vertical_speed, obj_wall))
 	while (!place_meeting(x, y + _onepixel, obj_wall)) y += _onepixel;
 	player_vertical_speed = 0;
 	player_vertical_speed_frac = 0;
+	
+	// Update the player spawn location (only if they are on the ground)
+	player_x_spawn = x;
+	player_y_spawn = y;
 }
 //Veritcal Move
 y += player_vertical_speed;

--- a/scripts/scr_macros/scr_macros.gml
+++ b/scripts/scr_macros/scr_macros.gml
@@ -9,3 +9,6 @@
 window_set_size(RES_W, RES_H);
 surface_resize(application_surface, RES_W, RES_H);
 display_set_gui_size(RES_W, RES_H);
+
+// Allows the game window (when not in full screen) to be fully within the monitor when initially compiled
+window_set_position(50, 50);


### PR DESCRIPTION
Adds functionality so that the player will get respawned at their last confirmed ground position.

Also adds an ease of life fix by adding the window_set_position to the macros script to ensure that when compiling and running in windowed mode that the screen won't be half off of the monitor.