### PR TITLE
Adjusting library to support test enablement/disablement

### DIFF
--- a/scripts/GMTL_init/GMTL_init.gml
+++ b/scripts/GMTL_init/GMTL_init.gml
@@ -4,14 +4,16 @@
 	Release date: 2024-07-19
 	Author:	DAndrëwBox
 */
-gml_pragma("global", "GMTL_init()");
-gml_pragma("global", "GMTL_definitions()");
-gml_pragma("global", "GMTL_internal()");
-gml_pragma("global", "GMTL_core_test_setup()");
-gml_pragma("global", "GMTL_core_test_events()");
-gml_pragma("global", "GMTL_core_TestCase()");
+if (ENABLE_TESTS) {
+	gml_pragma("global", "GMTL_init()");
+	gml_pragma("global", "GMTL_definitions()");
+	gml_pragma("global", "GMTL_internal()");
+	gml_pragma("global", "GMTL_core_test_setup()");
+	gml_pragma("global", "GMTL_core_test_events()");
+	gml_pragma("global", "GMTL_core_TestCase()");
 
-gml_pragma("global", "__gmtl_init()");
+	gml_pragma("global", "__gmtl_init()");
+}
 
 /// @func __gmtl_init()
 function __gmtl_init() {

--- a/scripts/scr_macros/scr_macros.gml
+++ b/scripts/scr_macros/scr_macros.gml
@@ -1,5 +1,7 @@
 // Location for all macro definitions
 
+#macro ENABLE_TESTS true // Set to false to remove tests from build
+
 // For a simple and easy to add to/expand screen resolution. A 16:9 aspect ratio.
 #macro RES_W 320
 #macro RES_H 180


### PR DESCRIPTION
PR to add flag for enabling/disabling tests
We should be able to use CI to adjust this for build purposes for release.
Based on the linked youtube video in the Discord, this should cover all of the scripts.
I've already set the flag covering all of the non-script assets. So builds should now be minimal asset load (based on what Gamemaker determines).