### PR TITLE
Add options for easier button input

### DIFF
--- a/objects/obj_np_button/Create_0.gml
+++ b/objects/obj_np_button/Create_0.gml
@@ -18,6 +18,3 @@ np_button_timer = 0;
 // The minimum time difference between when the button was pressed and when it should go back to normal.
 // The time is tracked in microseconds (1 millon to each second)
 np_button_time_diff = 300000;
-
-// Indicates if easy mode for entering answers in on
-np_easy_buttons = global.easy_buttons;

--- a/objects/obj_np_button/Create_0.gml
+++ b/objects/obj_np_button/Create_0.gml
@@ -18,3 +18,6 @@ np_button_timer = 0;
 // The minimum time difference between when the button was pressed and when it should go back to normal.
 // The time is tracked in microseconds (1 millon to each second)
 np_button_time_diff = 300000;
+
+// Indicates if easy mode for entering answers in on
+np_easy_buttons = global.easy_buttons;

--- a/objects/obj_np_button/Step_0.gml
+++ b/objects/obj_np_button/Step_0.gml
@@ -51,7 +51,7 @@ if (np_button_can_input && np_button_pressed && instance_exists(obj_np_equation)
 	{
 		with (obj_np_equation)
 		{
-			if (other.np_easy_buttons)
+			if (obj_settings_menu.sm_easy_buttons)
 			{
 				// Prevents accessing indixes beyond the length of the solution
 				var _still_input = string_length(string(np_equation_input)) < string_length(string(np_equation_equation_solution))

--- a/objects/obj_np_button/Step_0.gml
+++ b/objects/obj_np_button/Step_0.gml
@@ -51,9 +51,19 @@ if (np_button_can_input && np_button_pressed && instance_exists(obj_np_equation)
 	{
 		with (obj_np_equation)
 		{
+			if (other.np_easy_buttons)
+			{
+				// Prevents accessing indixes beyond the length of the solution
+				var _still_input = string_length(string(np_equation_input)) < string_length(string(np_equation_equation_solution))
+				// Only enter the numpad value if it matches the correct answer
+				if(_still_input && string_char_at(string(np_equation_equation_solution), string_length(string(np_equation_input)) + 1) == other.np_button_key_value)
+				{
+					np_equation_input += string_digits(other.np_button_key_value); 
+				}
+			}
 			// Prevents the diplayed text from being cut off due too there being more player input
 			// than what can be displayed
-			if (string_length(np_equation_text_current) < np_equation_shown_letters_cap)
+			else if (string_length(np_equation_text_current) < np_equation_shown_letters_cap)
 			{
 				np_equation_input += string_digits(other.np_button_key_value);
 			}

--- a/objects/obj_settings_menu/Create_0.gml
+++ b/objects/obj_settings_menu/Create_0.gml
@@ -12,6 +12,7 @@ adjusted_music_volume = 0.5;
 adjusted_sfx_volume = 0.5;
 is_fullscreen = 0;
 resolution = 720;
+sm_easy_buttons = false;
 
 // UI adjustments based on display and font size
 settings_menu_font_size = font_get_size(fnt_menu);
@@ -26,7 +27,9 @@ settings_menu_option[3] = "";
 settings_menu_option[4] = "Fullscreen: ";
 settings_menu_option[5] = "Resolution: ";
 settings_menu_option[6] = "";
-settings_menu_option[7] = "Exit Settings";
+settings_menu_option[7] = "Use easy buttons: ";
+settings_menu_option[8] = "";
+settings_menu_option[9] = "Exit Settings";
 
 settings_menu_cursor_position = 0;
 
@@ -38,4 +41,6 @@ settings_menu_value[3] = "";
 settings_menu_value[4] = "No";
 settings_menu_value[5] = "720p";
 settings_menu_value[6] = "";
-settings_menu_value[7] = "";
+settings_menu_value[7] = "False";
+settings_menu_value[8] = "";
+settings_menu_value[9] = "";

--- a/objects/obj_settings_menu/Step_0.gml
+++ b/objects/obj_settings_menu/Step_0.gml
@@ -16,6 +16,7 @@ if (in_settings_menu)
 			{
 				case SETTINGS_MENU.EMPTY_1:
 				case SETTINGS_MENU.EMPTY_2:
+				case SETTINGS_MENU.EMPTY_3:
 					settings_menu_cursor_position --;
 					break;
 			}
@@ -33,6 +34,7 @@ if (in_settings_menu)
 			{
 				case SETTINGS_MENU.EMPTY_1:
 				case SETTINGS_MENU.EMPTY_2:
+				case SETTINGS_MENU.EMPTY_3:
 					settings_menu_cursor_position ++;
 					break;
 			}
@@ -121,6 +123,27 @@ if (in_settings_menu)
 				resolution = resolution + RES_H;
 				settings_menu_value[5] = string(resolution) + "p"
 				window_set_size(resolution * 16/9, resolution);
+			}
+			break;
+			
+			// Easy button toggle
+		case SETTINGS_MENU.EASY_BUTTON:
+			if (global.key_left || global.key_right)
+			{
+				if (sm_easy_buttons)
+				{
+					// Toggle fullscreen off
+					settings_menu_value[7] = "False";
+					sm_easy_buttons = false;
+					global.easy_buttons = false;
+				}
+				else
+				{
+					// Toggle fullscreen on
+					settings_menu_value[7] = "True";
+					sm_easy_buttons = true;
+					global.easy_buttons = true;
+				}
 			}
 			break;
 		

--- a/objects/obj_settings_menu/Step_0.gml
+++ b/objects/obj_settings_menu/Step_0.gml
@@ -132,17 +132,15 @@ if (in_settings_menu)
 			{
 				if (sm_easy_buttons)
 				{
-					// Toggle fullscreen off
+					// Toggle easy button mode off
 					settings_menu_value[7] = "False";
 					sm_easy_buttons = false;
-					global.easy_buttons = false;
 				}
 				else
 				{
-					// Toggle fullscreen on
+					// Toggle easy button mode on
 					settings_menu_value[7] = "True";
 					sm_easy_buttons = true;
-					global.easy_buttons = true;
 				}
 			}
 			break;

--- a/scripts/scr_enums/scr_enums.gml
+++ b/scripts/scr_enums/scr_enums.gml
@@ -8,7 +8,9 @@ enum SETTINGS_MENU
 	FULLSCREEN = 4,
 	RESOLUTION = 5,
 	EMPTY_2 = 6,
-	EXIT_SETTINGS = 7
+	EASY_BUTTON = 7,
+	EMPTY_3 = 8,
+	EXIT_SETTINGS = 9
 }
 
 // Enum for orientation. The values are the angles of the object within the room.

--- a/scripts/scr_global_variables/scr_global_variables.gml
+++ b/scripts/scr_global_variables/scr_global_variables.gml
@@ -27,6 +27,3 @@ global.monotype_font = font_add_sprite(spr_monotype_font, ord("!"), false, 0);
 
 // Vegeta number for completed sockets
 global.over_9000 = -9001
-
-// Indicates if the easy mode for entering answers via numpad buttons should be used
-global.easy_buttons = false;

--- a/scripts/scr_global_variables/scr_global_variables.gml
+++ b/scripts/scr_global_variables/scr_global_variables.gml
@@ -27,3 +27,6 @@ global.monotype_font = font_add_sprite(spr_monotype_font, ord("!"), false, 0);
 
 // Vegeta number for completed sockets
 global.over_9000 = -9001
+
+// Indicates if the easy mode for entering answers via numpad buttons should be used
+global.easy_buttons = false;

--- a/scripts/scr_load_from_ini/scr_load_from_ini.gml
+++ b/scripts/scr_load_from_ini/scr_load_from_ini.gml
@@ -23,6 +23,10 @@ function scr_load_from_ini() {
 		window_set_size(resolution * 16/9, resolution);
 		window_set_fullscreen(bool(is_fullscreen));
 		
+		// Load difficulty options
+		sm_easy_buttons = ini_read_real("Difficulty", "Easy_buttons", false);
+		global.easy_buttons = sm_easy_buttons;
+		
 		// convert to padded strings
 		settings_menu_value[0] = "00" + string(main_volume) + "%";
 		settings_menu_value[0] = string_delete(settings_menu_value[0], 1, (string_length(string(main_volume))-1));
@@ -32,6 +36,7 @@ function scr_load_from_ini() {
 		settings_menu_value[2] = string_delete(settings_menu_value[2], 1, (string_length(string(sfx_volume))-1));
 		settings_menu_value[4] = bool(is_fullscreen) ? "True" : "False";
 		settings_menu_value[5] = string(resolution) + "p";
+		settings_menu_value[7] = sm_easy_buttons ? "True" : "False";
 	}
 	
 	ini_close();

--- a/scripts/scr_load_from_ini/scr_load_from_ini.gml
+++ b/scripts/scr_load_from_ini/scr_load_from_ini.gml
@@ -25,7 +25,6 @@ function scr_load_from_ini() {
 		
 		// Load difficulty options
 		sm_easy_buttons = ini_read_real("Difficulty", "Easy_buttons", false);
-		global.easy_buttons = sm_easy_buttons;
 		
 		// convert to padded strings
 		settings_menu_value[0] = "00" + string(main_volume) + "%";

--- a/scripts/scr_save_to_ini/scr_save_to_ini.gml
+++ b/scripts/scr_save_to_ini/scr_save_to_ini.gml
@@ -9,6 +9,7 @@ function scr_save_settings_to_file()
 		ini_write_real("Volume", "SFX", sfx_volume);
 		ini_write_real("Display", "Fullscreen", is_fullscreen);
 		ini_write_real("Display", "Resolution", resolution);
+		ini_write_real("Difficulty", "Easy_buttons", sm_easy_buttons);
 		ini_close();
 	}
 }


### PR DESCRIPTION
Adds a new setting for toggling easy buttons.

Easy buttons makes it so that if you hit a button that isn't the correct next number for the answer, nothing happens. Basically removing the need for the backspace button, but making the numpad mechanic notably easier to complete.