### PR TITLE
Add temporary capabilities of main menu level list

### DIFF
--- a/objects/obj_main_menu/Create_0.gml
+++ b/objects/obj_main_menu/Create_0.gml
@@ -16,12 +16,22 @@ main_menu_committed = -1;
 
 main_menu_control = true;
 
-main_menu_options[5] = "Settings";
-main_menu_options[4] = "Level 3";
-main_menu_options[3] = "Level 2";
-main_menu_options[2] = "Level 1";
-main_menu_options[1] = "Continue";
-main_menu_options[0] = "Quit";
+// Temporary values for an easier way to add rooms for testing
+main_menu_lvl_list_selector = 0;
+main_menu_lvl_list_names[2] = "lvl_three";
+main_menu_lvl_list_names[1] = "lvl_two";
+main_menu_lvl_list_names[0] = "lvl_one";
+main_menu_tmp_lvl_list[2] = rm_lvl_three;
+main_menu_tmp_lvl_list[1] = rm_lvl_two;
+main_menu_tmp_lvl_list[0] = rm_lvl_one;
+main_menu_options[MAIN_MENU.LEVEL_LIST] = main_menu_lvl_list_names[main_menu_lvl_list_selector];
 
-main_menu_items = array_length(main_menu_options);
-main_menu_cursor = 2;
+main_menu_options[MAIN_MENU.SETTINGS] = "Settings";
+main_menu_options[MAIN_MENU.LEVEL_THREE] = "Level 3";
+main_menu_options[MAIN_MENU.LEVEL_TWO] = "Level 2";
+main_menu_options[MAIN_MENU.LEVEL_ONE] = "Level 1";
+main_menu_options[MAIN_MENU.CONTINUE] = "Continue";
+main_menu_options[MAIN_MENU.QUIT] = "Quit";
+
+main_menu_items = array_length(main_menu_options) - 1;
+main_menu_cursor = MAIN_MENU.LEVEL_ONE;

--- a/objects/obj_main_menu/Draw_64.gml
+++ b/objects/obj_main_menu/Draw_64.gml
@@ -2,7 +2,7 @@
 
 scr_draw_set_text(c_white, fnt_menu, fa_right, fa_bottom);
 
-for (var _i = 0; _i < main_menu_items; _i++)
+for (var _i = 0; _i <= main_menu_items; _i++)
 {
 	var _txt = main_menu_options[_i];
 	var _col = c_gray;
@@ -12,7 +12,7 @@ for (var _i = 0; _i < main_menu_items; _i++)
 		_col = c_white;
 	}
 	
-	var _yy = main_menu_y - (main_menu_item_height * (_i * 1));
+	var _yy = main_menu_y - (main_menu_item_height * _i);
 	scr_draw_text_outline(main_menu_x, _yy, _col, c_black, global.text_offset, _txt, 0.5);
 }
 

--- a/objects/obj_main_menu/Step_0.gml
+++ b/objects/obj_main_menu/Step_0.gml
@@ -7,19 +7,34 @@ if (main_menu_control && !obj_settings_menu.in_settings_menu)
 {
 	if (global.key_up)
 	{
-		main_menu_cursor++;
-		if (main_menu_cursor >= main_menu_items) main_menu_cursor = 0;
+		++main_menu_cursor;
+		// Loop to the bottom option
+		if (main_menu_cursor > main_menu_items) main_menu_cursor = 0;
 	}
 	
 	if (global.key_down)
 	{
 		main_menu_cursor--;
-		if (main_menu_cursor < 0) main_menu_cursor = main_menu_items - 1;
+		if (main_menu_cursor < 0) main_menu_cursor = main_menu_items;
+	}
+	
+	if (main_menu_cursor == MAIN_MENU.LEVEL_LIST)
+	{
+		if (global.key_left && (main_menu_lvl_list_selector > 0))
+		{
+			main_menu_lvl_list_selector--;
+			main_menu_options[MAIN_MENU.LEVEL_LIST] = main_menu_lvl_list_names[main_menu_lvl_list_selector]
+		}
+		if (global.key_right && (main_menu_lvl_list_selector < array_length(main_menu_tmp_lvl_list) - 1))
+		{
+			main_menu_lvl_list_selector++;
+			main_menu_options[MAIN_MENU.LEVEL_LIST] = main_menu_lvl_list_names[main_menu_lvl_list_selector]
+		}
 	}
 	
 	if (global.key_select)
 	{
-		if (main_menu_cursor == 5)
+		if (main_menu_cursor == MAIN_MENU.SETTINGS)
 		{
 			obj_settings_menu.settings_menu_cursor_position = 0;
 			obj_settings_menu.in_settings_menu = true;
@@ -35,15 +50,15 @@ if (main_menu_control && !obj_settings_menu.in_settings_menu)
 	}
 }
 
-// TODO: this check is really stupid and should be changed
 if (main_menu_x > main_menu_gui_width + 50) && (main_menu_committed != -1)
 {
 	switch (main_menu_committed)
 	{
-		case 4: scr_slide_transition(TRANS_MODE.GOTO, rm_lvl_three); break;
-		case 3: scr_slide_transition(TRANS_MODE.GOTO, rm_lvl_two); break;
-		case 2: scr_slide_transition(TRANS_MODE.GOTO, rm_lvl_one); break;
-		case 1:
+		case MAIN_MENU.LEVEL_LIST: scr_slide_transition(TRANS_MODE.GOTO, main_menu_tmp_lvl_list[main_menu_lvl_list_selector]); break;
+		case MAIN_MENU.LEVEL_THREE: scr_slide_transition(TRANS_MODE.GOTO, rm_lvl_three); break;
+		case MAIN_MENU.LEVEL_TWO: scr_slide_transition(TRANS_MODE.GOTO, rm_lvl_two); break;
+		case MAIN_MENU.LEVEL_ONE: scr_slide_transition(TRANS_MODE.GOTO, rm_lvl_one); break;
+		case MAIN_MENU.CONTINUE:
 		{
 			ini_open("settings.ini");
 			var _last_level = ini_read_string("Level", "Last Completed", "new_game");
@@ -51,6 +66,6 @@ if (main_menu_x > main_menu_gui_width + 50) && (main_menu_committed != -1)
 			scr_level_mapping(_last_level);
 		}
 		break;
-		case 0: game_end(); break;
+		case MAIN_MENU.QUIT: game_end(); break;
 	}
 }

--- a/scripts/scr_enums/scr_enums.gml
+++ b/scripts/scr_enums/scr_enums.gml
@@ -46,3 +46,15 @@ enum EQUATION_DIFFICULTY
 	MEDUIM = 2,
 	HARD = 3
 }
+
+// Enum for navigating the main menu
+enum MAIN_MENU
+{
+	QUIT = 0,
+	CONTINUE = 1,
+	LEVEL_ONE = 2,
+	LEVEL_TWO = 3,
+	LEVEL_THREE = 4,
+	SETTINGS = 5,
+	LEVEL_LIST = 6
+}


### PR DESCRIPTION
This can be removed later, or moved to a place that is hidden to the players but accessible to the devs for future level testing.

Can now just add two lines to add a new level to be selected in the main menu
Cleaned up some old bad code

I have done rudimentary testing of the code and it seems to work as intended.